### PR TITLE
Make script run all functions

### DIFF
--- a/extract-library-data.py
+++ b/extract-library-data.py
@@ -185,11 +185,11 @@ def variable_actions_by_team():
 
 
 def main():
-    # actions_by_component()
-    # actions_by_team()
-    # usages_by_component()
-    # usages_by_file()
-    # variable_actions_by_variable()
+    actions_by_component()
+    actions_by_team()
+    usages_by_component()
+    usages_by_file()
+    variable_actions_by_variable()
     variable_actions_by_team()
 
 


### PR DESCRIPTION
When running `python3 extract-library-data.py` only the `variable_actions_by_team()` function outputs by default.

This is because the other functions are commented out:

https://github.com/gerard-figma/figma-library-analytics-api-example/blob/049443879515d4622d098e933a0888ad5a29876c/extract-library-data.py#L188-L192

I was able to run all the functions as part of the script without apparent error.

Sorry if it is intentional and I've misunderstood.